### PR TITLE
audio: Add audio amplifier HAL

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -70,3 +70,16 @@ cc_library_shared {
         "uevent.c",
     ],
 }
+
+// The stub audio amplifier HAL module that can be used as a skeleton for
+// new implementations.
+cc_library_shared {
+    name: "audio_amplifier.default",
+    relative_install_path: "hw",
+    proprietary: true,
+    srcs: ["audio_amplifier.c"],
+    shared_libs: [
+        "liblog",
+    ],
+    cflags: ["-Wall", "-Werror", "-Wno-unused-parameter"],
+}

--- a/include/hardware/audio_amplifier.h
+++ b/include/hardware/audio_amplifier.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2015, The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CM_AUDIO_AMPLIFIER_INTERFACE_H
+#define CM_AUDIO_AMPLIFIER_INTERFACE_H
+
+#include <stdint.h>
+#include <sys/cdefs.h>
+#include <sys/types.h>
+
+#include <hardware/audio.h>
+#include <hardware/hardware.h>
+
+#include <system/audio.h>
+
+__BEGIN_DECLS
+
+#define AMPLIFIER_HARDWARE_MODULE_ID "audio_amplifier"
+
+#define AMPLIFIER_HARDWARE_INTERFACE "audio_amplifier_hw_if"
+
+#define AMPLIFIER_MODULE_API_VERSION_0_1 HARDWARE_MODULE_API_VERSION(0, 1)
+
+#define AMPLIFIER_DEVICE_API_VERSION_1_0 HARDWARE_DEVICE_API_VERSION(1, 0)
+#define AMPLIFIER_DEVICE_API_VERSION_2_0 HARDWARE_DEVICE_API_VERSION(2, 0)
+#define AMPLIFIER_DEVICE_API_VERSION_2_1 HARDWARE_DEVICE_API_VERSION(2, 1)
+#define AMPLIFIER_DEVICE_API_VERSION_CURRENT AMPLIFIER_DEVICE_API_VERSION_2_1
+
+struct str_parms;
+
+typedef struct amplifier_device {
+    /**
+     * Common methods of the amplifier device. This *must* be the first member
+     * of amplifier_device as users of this structure will cast a hw_device_t
+     * to amplifier_device pointer in contexts where it's known
+     * the hw_device_t references a amplifier_device.
+     */
+    struct hw_device_t common;
+
+    /**
+     * Notify amplifier device of current input devices
+     *
+     * This function should handle only input devices.
+     */
+    int (*set_input_devices)(struct amplifier_device *device, uint32_t devices);
+
+    /**
+     * Notify amplifier device of current output devices
+     *
+     * This function should handle only output devices.
+     */
+    int (*set_output_devices)(struct amplifier_device *device, uint32_t devices);
+
+    /**
+     * Notify amplifier device of output device enable/disable
+     *
+     * This function should handle only output devices.
+     */
+    int (*enable_output_devices)(struct amplifier_device *device,
+            uint32_t devices, bool enable);
+
+    /**
+     * Notify amplifier device of input device enable/disable
+     *
+     * This function should handle only input devices.
+     */
+    int (*enable_input_devices)(struct amplifier_device *device,
+            uint32_t devices, bool enable);
+
+    /**
+     * Notify amplifier device about current audio mode
+     */
+    int (*set_mode)(struct amplifier_device *device, audio_mode_t mode);
+
+    /**
+     * Notify amplifier device that an output stream has started
+     */
+    int (*output_stream_start)(struct amplifier_device *device,
+            struct audio_stream_out *stream, bool offload);
+
+    /**
+     * Notify amplifier device that an input stream has started
+     */
+    int (*input_stream_start)(struct amplifier_device *device,
+            struct audio_stream_in *stream);
+
+    /**
+     * Notify amplifier device that an output stream has stopped
+     */
+    int (*output_stream_standby)(struct amplifier_device *device,
+            struct audio_stream_out *stream);
+
+    /**
+     * Notify amplifier device that an input stream has stopped
+     */
+    int (*input_stream_standby)(struct amplifier_device *device,
+            struct audio_stream_in *stream);
+
+    /**
+     * set/get audio device parameters.
+     */
+    int (*set_parameters)(struct amplifier_device *device,
+        struct str_parms *parms);
+
+    /**
+     * set/get output stream parameters.
+     */
+    int (*out_set_parameters)(struct amplifier_device *device,
+        struct str_parms *parms);
+
+    /**
+     * set/get input stream parameters.
+     */
+    int (*in_set_parameters)(struct amplifier_device *device,
+        struct str_parms *parms);
+} amplifier_device_t;
+
+typedef struct amplifier_module {
+    /**
+     * Common methods of the amplifier module. This *must* be the first member
+     * of amplifier_module as users of this structure will cast a hw_module_t
+     * to amplifier_module pointer in contexts where it's known
+     * the hw_module_t references a amplifier_module.
+     */
+    struct hw_module_t common;
+} amplifier_module_t;
+
+/** convenience API for opening and closing a supported device */
+
+static inline int amplifier_device_open(const struct hw_module_t *module,
+        struct amplifier_device **device)
+{
+    return module->methods->open(module, AMPLIFIER_HARDWARE_INTERFACE,
+            (struct hw_device_t **) device);
+}
+
+static inline int amplifier_device_close(struct amplifier_device *device)
+{
+    return device->common.close(&device->common);
+}
+
+__END_DECLS
+
+#endif  // CM_AUDIO_AMPLIFIER_INTERFACE_H

--- a/modules/audio/audio_amplifier.c
+++ b/modules/audio/audio_amplifier.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2015 The CyanogenMod Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "amplifier_default"
+//#define LOG_NDEBUG 0
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/types.h>
+
+#include <cutils/log.h>
+#include <cutils/str_parms.h>
+
+#include <hardware/audio_amplifier.h>
+#include <hardware/hardware.h>
+
+static int amp_set_input_devices(amplifier_device_t *device, uint32_t devices)
+{
+    return 0;
+}
+
+static int amp_set_output_devices(amplifier_device_t *device, uint32_t devices)
+{
+    return 0;
+}
+
+static int amp_enable_output_devices(amplifier_device_t *device,
+        uint32_t devices, bool enable)
+{
+    return 0;
+}
+
+static int amp_enable_input_devices(amplifier_device_t *device,
+        uint32_t devices, bool enable)
+{
+    return 0;
+}
+
+static int amp_set_mode(amplifier_device_t *device, audio_mode_t mode)
+{
+    return 0;
+}
+
+static int amp_output_stream_start(amplifier_device_t *device,
+        struct audio_stream_out *stream, bool offload)
+{
+    return 0;
+}
+
+static int amp_input_stream_start(amplifier_device_t *device,
+        struct audio_stream_in *stream)
+{
+    return 0;
+}
+
+static int amp_output_stream_standby(amplifier_device_t *device,
+        struct audio_stream_out *stream)
+{
+    return 0;
+}
+
+static int amp_input_stream_standby(amplifier_device_t *device,
+        struct audio_stream_in *stream)
+{
+    return 0;
+}
+
+static int amp_set_parameters(struct amplifier_device *device,
+        struct str_parms *parms)
+{
+    return 0;
+}
+
+static int amp_out_set_parameters(struct amplifier_device *device,
+        struct str_parms *parms)
+{
+    return 0;
+}
+
+static int amp_in_set_parameters(struct amplifier_device *device,
+        struct str_parms *parms)
+{
+    return 0;
+}
+
+static int amp_dev_close(hw_device_t *device)
+{
+    if (device)
+        free(device);
+
+    return 0;
+}
+
+static int amp_module_open(const hw_module_t *module, const char *name,
+        hw_device_t **device)
+{
+    if (strcmp(name, AMPLIFIER_HARDWARE_INTERFACE)) {
+        ALOGE("%s:%d: %s does not match amplifier hardware interface name\n",
+                __func__, __LINE__, name);
+        return -ENODEV;
+    }
+
+    amplifier_device_t *amp_dev = calloc(1, sizeof(amplifier_device_t));
+    if (!amp_dev) {
+        ALOGE("%s:%d: Unable to allocate memory for amplifier device\n",
+                __func__, __LINE__);
+        return -ENOMEM;
+    }
+
+    amp_dev->common.tag = HARDWARE_DEVICE_TAG;
+    amp_dev->common.module = (hw_module_t *) module;
+    amp_dev->common.version = HARDWARE_DEVICE_API_VERSION(1, 0);
+    amp_dev->common.close = amp_dev_close;
+
+    amp_dev->set_input_devices = amp_set_input_devices;
+    amp_dev->set_output_devices = amp_set_output_devices;
+    amp_dev->enable_output_devices = amp_enable_output_devices;
+    amp_dev->enable_input_devices = amp_enable_input_devices;
+    amp_dev->set_mode = amp_set_mode;
+    amp_dev->output_stream_start = amp_output_stream_start;
+    amp_dev->input_stream_start = amp_input_stream_start;
+    amp_dev->output_stream_standby = amp_output_stream_standby;
+    amp_dev->input_stream_standby = amp_input_stream_standby;
+    amp_dev->set_parameters = amp_set_parameters;
+    amp_dev->out_set_parameters = amp_out_set_parameters;
+    amp_dev->in_set_parameters = amp_in_set_parameters;
+
+    *device = (hw_device_t *) amp_dev;
+
+    return 0;
+}
+
+static struct hw_module_methods_t hal_module_methods = {
+    .open = amp_module_open,
+};
+
+amplifier_module_t HAL_MODULE_INFO_SYM = {
+    .common = {
+        .tag = HARDWARE_MODULE_TAG,
+        .module_api_version = AMPLIFIER_MODULE_API_VERSION_0_1,
+        .hal_api_version = HARDWARE_HAL_API_VERSION,
+        .id = AMPLIFIER_HARDWARE_MODULE_ID,
+        .name = "Default audio amplifier HAL",
+        .author = "The CyanogenMod Open Source Project",
+        .methods = &hal_module_methods,
+    },
+};


### PR DESCRIPTION
This is a squash of the following commits.

commit dabc25c1d073a0f32b706e59b87ac89f67389107
Author: Ethan Chen <intervigil@gmail.com>
Date:   Fri, 03 Jul 2015 21:35:30 -0700

    audio: Notify amplifier HAL of device enable/disable

    Change-Id: Ice808c9b55a9e3bc8bafe5ca3ff555377d38dd8f

commit 5b2337c434acff34d85ae14b9cc2d3507fdffe52
Author: Scott Mertz <scott@cyngn.com>
Date:   Fri, 11 Sep 2015 12:09:06 -0700

    amplifier: add set_parameters method

    - audio hal should pass the audio_device parameters to the amplifier
      to allow the amplifier to make decisions based on the additional
      parameters.  For example, we may want to change settings for DTS
      TrueMedia use case.

    Change-Id: Iccf6ef7ced2abd2e12e857eea8e580cda15eec04

commit 6a6c815e74bc9c8da0cead508dfa722229ea878f
Author: Scott Mertz <scott@cyngn.com>
Date: Wed, 21 Oct 2015 10:11:49 -0700

    audio_amplifier: fix compilation

    stdlib.h is needed explicitely with the new
    toolchain/toolchain options.

    Change-Id: I876041828310ec8f9fb1e0d636a38cce1977d9b9

commit dcc6b5fd693b129492a45ec75038ca582689bd5d
Author: Ethan Chen <intervigil@gmail.com>
Date: Fri, 15 Jan 2016 16:12:39 -0800

    amplifier: Fix compilation warning

    * Forward declare str_parms

    Change-Id: Iafb0ad8e4b0696807cfe568d0f89ce5dad6bcade

commit 978ac098d6cde55bc5090ea83a9bda2ee176577b
Author: codeworkx <daniel.hillenbrand@codeworkx.de>
Date:   Sat Mar 24 21:30:34 2018 +0100

    audio_amplifier: add hooks for stream parameter manipulation

    This allows to modify audio parameters before the first
    device selection happens which is necessary when setting ANC parameter
    since it must happen before audio hal hits voice_start_call() and
    selects devices. If setting ANC after stream has been started it will
    trigger a re-selection of devices and cause a short downtime.

    Change-Id: Icfddab5ce27235c1567a0557e63b3a7421778187

Change-Id: I0473143057d542c8fa0a3ec4a67ce277900badbe